### PR TITLE
Fix opening new tab in directories with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ let curPid;
 let uids = {};
 
 const setCwd = (pid) =>
-  exec(`lsof -p ${pid} | grep cwd | awk '$4 == "cwd" {print $9}'`, (err, cwd) => {
+  exec(`lsof -p ${pid} | grep cwd | tr -s ' ' | cut -d ' ' -f9-`, (err, cwd) => {
     if (err) {
       console.error(err);
     } else {


### PR DESCRIPTION
When opening a new tab in a directory that contained spaces I was getting an exception so I replaced the awk script with tr (to trim extra whitespace) and cut (to get everything from the ninth field, including spaces).