### PR TITLE
Add .npmignore and ignore demo gif

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+newTabs.gif


### PR DESCRIPTION
Noticed that demo gif was in my `~/.hyperterm_plugins` when it didn't need to be. 🍻