### PR TITLE
Fix missing reference (tabId) in windowsSetCwd()

### DIFF
--- a/setCwd.js
+++ b/setCwd.js
@@ -22,7 +22,7 @@ const windowsSetCwd = ({ dispatch, action, tab, curTabId }) => {
   const newCwd = directoryRegex.exec(action.data);
   if (newCwd) {
     const cwd = newCwd[0];
-    if (tab.cwd !== cwd && tabId === curTabId) {
+    if (tab.cwd !== cwd && action.uid === curTabId) {
       dispatch({
         type: 'SESSION_SET_CWD',
         cwd,


### PR DESCRIPTION
Hi,
Not sure if this is the best fix but this change does the job.
The body of windowsSetCwd has been copied from index.js. However the signature has changed, and tabId is no longer passed as an argument. Since the caller already sets curTabId as action.uid, I propose a fix to replace missing tabId with action.uid, although it also makes sense to remove the `tabId === curTabId` condition altogether, because now it will always be true.