### PR TITLE
Support bash on Windows 10

### DIFF
--- a/setCwd.js
+++ b/setCwd.js
@@ -14,21 +14,29 @@ const setCwd = async ({ dispatch, action, tab }) => {
 };
 
 // For Windows Support:
-// the final excluded character () is an odd character
-// that was added to the end of the line by posh-hg/posh-git
-const directoryRegex = /([a-zA-Z]:[^\:\[\]\?\"\<\>\|]+)/mi;
+// the final excluded () and () characters
+// that was added by posh-hg/posh-git and bash
+const reMsShell = /([A-Z]:(([^\s][^\:\[\]\?\"\<\>\|]+)|\\))/mi;
+const reLinuxShell = /\:\s\/mnt\/([A-Z])([^\:\[\]\?\"\<\>\|]+)?/mi;
+
+const parseWindowsCwd = (data) => {
+  const linuxCwd = reLinuxShell.exec(data);
+  if (linuxCwd) return [linuxCwd[1].toUpperCase(), linuxCwd[2] || '/'].join(':');
+
+  const msCwd = reMsShell.exec(data);
+  if (msCwd) return msCwd[0];
+}
 
 const windowsSetCwd = ({ dispatch, action, tab, curTabId }) => {
-  const newCwd = directoryRegex.exec(action.data);
+  const newCwd = parseWindowsCwd(action.data);
   if (newCwd) {
-    const cwd = newCwd[0];
-    if (tab.cwd !== cwd && action.uid === curTabId) {
+    if (tab.cwd !== newCwd && action.uid === curTabId) {
       dispatch({
         type: 'SESSION_SET_CWD',
-        cwd,
+        cwd: newCwd
       });
     }
-    tab.cwd = cwd;
+    tab.cwd = newCwd;
   }
 };
 


### PR DESCRIPTION
`shell: 'C:\\Windows\\System32\\bash.exe'` in settings

When I open a new tab I got the exception:
```
Uncaught Exception:
Error: Unable to start terminal process: CreateProcess failed
    at new WindowsPtyAgent (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\node_modules\node-pty\lib\windowsPtyAgent.js:25:24)
    at new WindowsTerminal (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\node_modules\node-pty\lib\windowsTerminal.js:45:24)
    at spawn (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\node_modules\node-pty\lib\index.js:27:12)
    at Session (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\session.js:53:18)
    at initSession (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\ui\window.js:102:24)
    at Server.Window.rpc.on.options (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\ui\window.js:105:7)
    at emitOne (events.js:115:13)
    at Server.emit (events.js:210:7)
    at Server.ipcListener (C:\Users\n0xff\AppData\Local\hyper\app-2.1.0-canary1\resources\app.asar\rpc.js:33:11)
    at emitTwo (events.js:125:13)
```

In bash `action.data` return:
```
"]0;virtual@MAIN-PC: /mnt/c[0;32;92mvirtual@MAIN-PC[0m:[0;34;94m/mnt/c/Users/n0xff[0m$[0K[37G"
```

After parsing this data the `cwd` variable value is `C: /mnt/c`. So Hyper can't start a new session with wrong `cwd`.

If we want open _bash.exe_ with our folder we need use _cmd_ arguments `bash.exe -c "cd /mnt/"` or change current folder before opening _bash.exe_ (and he open bash in current folder). I don't know can we send additional arguments to Hyper or not, but we can change current folder in right way.

I extend regexp and add transform from Linux path in Windows. So above data now will return correct folder path `C:/Users/n0xff`.

Was tested in default cmd.exe and bash.exe shell.