### PR TITLE
fix: Can't open new tab when current path contains multibyte characters

### DIFF
--- a/setCwd.js
+++ b/setCwd.js
@@ -5,7 +5,7 @@ const promiseExec = promisify(exec);
 
 const setCwd = async ({ dispatch, action, tab }) => {
   const newCwd = await promiseExec(
-    `lsof -p ${tab.pid} | grep cwd | tr -s ' ' | cut -d ' ' -f9-`);
+    `LANG=en_US.UTF-8 lsof -p ${tab.pid} | grep cwd | tr -s ' ' | cut -d ' ' -f9-`);
   const cwd = newCwd.trim();
   dispatch({
     type: 'SESSION_SET_CWD',


### PR DESCRIPTION
fixes #53 

## Problem
When current path contains multibyte characters, action to open new tab fails.

```
$ mkdir 日本語
$ cd 日本語
```

## Cause
1. `LANG` env is empty when the command is executed from `child_process.exec`.
1. When `LANG` env is empty, the multibyte characters contained in the result of the `lsof` command are escaped.
    - e.g. `/path/to/dir/日本語` -> `/path/to/dir/\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e`
1. Due to `No such directory` error, `SESSION_SET_CWD` event fails.
1. The action to open a new tab fails.

## Solution
Specify `LANG=en_US.UTF-8` when execute `lsof` command.